### PR TITLE
Adjust cron to 6am Paris time

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -2,7 +2,8 @@ name: Daily AI News Pipeline
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # ⏰ Tous les jours à 6h UTC = 8h heure de Paris
+    - cron: '0 6 * * *'
+      timezone: 'Europe/Paris'  # ⏰ Tous les jours à 6h heure de Paris
   workflow_dispatch:     # ▶️ Permet de lancer manuellement
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ AI News Agent is an automated pipeline that collects technology news, cleans the
 These steps are executed sequentially by [`app.py`](app.py).
 
 ## Automation
-The workflow in [`.github/workflows/daily-pipeline.yml`](.github/workflows/daily-pipeline.yml) runs the pipeline at 06:00 UTC each day. The required secrets must be set in the repository for it to send emails and call the OpenAI API.
+The workflow in [`.github/workflows/daily-pipeline.yml`](.github/workflows/daily-pipeline.yml) runs the pipeline at 06:00 Paris time (using the `Europe/Paris` timezone) each day. The required secrets must be set in the repository for it to send emails and call the OpenAI API. Ensure the workflow file resides on your default branch so that the schedule triggers correctly.
 
 ## Data
 All article data and summaries are stored in the `data/` directory:


### PR DESCRIPTION
## Summary
- schedule the daily pipeline at 06:00 Paris time using the Europe/Paris timezone
- note the default-branch requirement in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d1a8b2a4832e9cc2ca47d3fc7dec