### PR TITLE
Disable scheduled workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -1,8 +1,6 @@
 name: Daily AI News Pipeline
 
 on:
-  schedule:
-    - cron: '0 6 * * *'  # ⏰ Tous les jours à 6h UTC = 8h Paris
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the cron trigger from the GitHub Actions workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fdeeb4b84832ebf9b40404b9f28c7